### PR TITLE
feat: internal bhop via CUserCmd button manipulation + subtick

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,8 @@ Checks: >
   modernize-use-using,
   -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,
-  -performance-no-int-to-ptr
+  -performance-no-int-to-ptr,
+  -clang-diagnostic-invalid-offsetof
 
 # Treat warnings as non-fatal so tidy integrates smoothly into dev workflow
 WarningsAsErrors: ''

--- a/.cppcheck-suppress
+++ b/.cppcheck-suppress
@@ -1,0 +1,6 @@
+// SDK overlay structs — game memory layouts, never constructed by us
+noConstructor:src/sdk/entitysystem.h
+noConstructor:src/sdk/usercmd.h
+
+// Engine Rep_t alignment padding
+unusedStructMember:src/sdk/usercmd.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(variant PRIVATE
     src/main.cpp
     src/core/interfaces.cpp
     src/sdk/entitysystem.cpp
+    src/sdk/usercmd.cpp
     src/core/hooks/hooks.cpp
     src/core/hooks/render/render.cpp
     src/core/hooks/cursor/cursor.cpp

--- a/src/core/hooks/createmove/createmove.cpp
+++ b/src/core/hooks/createmove/createmove.cpp
@@ -1,29 +1,45 @@
-// CreateMove hook — game input processing (bhop, etc.)
+// CreateMove hooks — CCSGOInput vtable[5] + vtable[22]
+// vtable[5]: passthrough (reserved for future features)
+// vtable[22]: bhop + subtick inject/restore
 
 #include "createmove.h"
 #include "../hooks.h"
+#include "../../interfaces.h"
+#include "../../../sdk/entitysystem.h"
+#include "../../../sdk/usercmd.h"
 #include "../../../features/movement.h"
-#include "../../../utilities/debug.h"
-#include <format>
 
-bool __fastcall CreateMove::hkCreateMove(void* pInput, int nSlot, void* pCmd)
+// -----------------------------------------------------------------------
+// vtable[5] — outer wrapper
+// -----------------------------------------------------------------------
+bool __fastcall CreateMove::hkCreateMove(void* pInput, int nSlot, bool bActive)
 {
     auto oCreateMove = DTR::CreateMove.Original<decltype(&hkCreateMove)>();
+    return oCreateMove(pInput, nSlot, bActive);
+}
 
-    if (!pCmd)
-        return oCreateMove(pInput, nSlot, pCmd);
+// -----------------------------------------------------------------------
+// vtable[22] — inner CreateMove (CUserCmd* access + subtick)
+// -----------------------------------------------------------------------
+bool __fastcall CreateMove::hkCreateMoveInner(void* pInput, int nSlot, void* pCmd)
+{
+    auto oCreateMoveInner = DTR::CreateMoveInner.Original<decltype(&hkCreateMoveInner)>();
 
-    // Log once
-    static bool s_loggedOnce = false;
-    if (!s_loggedOnce)
+    auto* cmd = static_cast<CUserCmd*>(pCmd);
+
+    // Feature processing BEFORE original — engine processes our modifications
+    if (cmd && pInput == I::pCSGOInput)
     {
-        C::Print(std::format("[createmove] hook firing | pInput: {:#x} | pCmd: {:#x}",
-                             reinterpret_cast<uintptr_t>(pInput), reinterpret_cast<uintptr_t>(pCmd)));
-        s_loggedOnce = true;
+        auto* pLocal = EntitySystem::GetLocalPlayerPawn();
+        if (pLocal && pLocal->m_iHealth > 0)
+            Movement::BunnyHop(cmd, pLocal);
     }
 
-    // Features — modify global state BEFORE oCreateMove reads it
-    Movement::BunnyHop();
+    bool result = oCreateMoveInner(pInput, nSlot, pCmd);
 
-    return oCreateMove(pInput, nSlot, pCmd);
+    // Restore subtick field after original (prevent engine cleanup of our static objects)
+    if (cmd && pInput == I::pCSGOInput && IsValidPtr(cmd->pBaseCmd))
+        Subtick::Restore(cmd->pBaseCmd);
+
+    return result;
 }

--- a/src/core/hooks/createmove/createmove.h
+++ b/src/core/hooks/createmove/createmove.h
@@ -1,8 +1,12 @@
 #pragma once
 #include "../../../includes.h"
 
-// CreateMove hook handler
+// CreateMove hooks on CCSGOInput
 namespace CreateMove
 {
-    bool __fastcall hkCreateMove(void* pInput, int nSlot, void* pCmd);
+    // vtable[5] — outer wrapper (button manipulation)
+    bool __fastcall hkCreateMove(void* pInput, int nSlot, bool bActive);
+
+    // vtable[22] — inner CreateMove (CUserCmd* access for subtick)
+    bool __fastcall hkCreateMoveInner(void* pInput, int nSlot, void* pCmd);
 }

--- a/src/core/hooks/hooks.cpp
+++ b/src/core/hooks/hooks.cpp
@@ -8,10 +8,6 @@
 #include "../../utilities/memory.h"
 #include "../../utilities/inputhook.h"
 
-// ---------------------------------------------------------------------------
-// Setup / Restore
-// ---------------------------------------------------------------------------
-
 bool H::Setup()
 {
     if (MH_Initialize() != MH_OK)
@@ -27,14 +23,11 @@ bool H::Setup()
         return false;
     }
 
-    // D3D11 hooks
     if (!DTR::Present.Create(vtable[VTABLE::PRESENT], &Render::hkPresent))
         return false;
-
     if (!DTR::ResizeBuffers.Create(vtable[VTABLE::RESIZEBUFFERS], &Render::hkResizeBuffers))
         return false;
 
-    // Cursor control: InputSystem vtable + SDL3
     if (I::pInputSystem)
     {
         if (!DTR::IsRelativeMouseMode.Create(M::GetVFunc(I::pInputSystem, VTABLE::ISRELATIVEMOUSEMODE),
@@ -54,17 +47,16 @@ bool H::Setup()
         }
     }
 
-    // CreateMove — function address resolved in I::Setup via pattern scan
+    // CCSGOInput vtable hooks
     if (I::pCSGOInput)
     {
-        if (!DTR::CreateMove.Create(I::pCSGOInput, reinterpret_cast<void*>(&CreateMove::hkCreateMove)))
+        if (!DTR::CreateMove.Create(M::GetVFunc(I::pCSGOInput, VTABLE::CREATEMOVE),
+                                    reinterpret_cast<void*>(&CreateMove::hkCreateMove)))
             C::Print("[hooks] failed to hook CreateMove (non-fatal)");
-        else
-            C::Print("[hooks] CreateMove hooked");
-    }
-    else
-    {
-        C::Print("[hooks] CreateMove not found — game features disabled");
+
+        if (!DTR::CreateMoveInner.Create(M::GetVFunc(I::pCSGOInput, VTABLE::CREATEMOVE_INNER),
+                                         reinterpret_cast<void*>(&CreateMove::hkCreateMoveInner)))
+            C::Print("[hooks] failed to hook CreateMoveInner (non-fatal)");
     }
 
     return true;
@@ -80,13 +72,13 @@ void H::Restore()
 
     Render::ReleaseRenderTarget();
 
+    DTR::CreateMoveInner.Remove();
     DTR::CreateMove.Remove();
     DTR::SDLSetRelMouseMode.Remove();
     DTR::IsRelativeMouseMode.Remove();
     DTR::Present.Remove();
     DTR::ResizeBuffers.Remove();
 
-    // Release COM refs acquired in InitImGui (GetDevice/GetImmediateContext AddRef)
     if (I::pContext)
     {
         I::pContext->Release();

--- a/src/core/hooks/hooks.h
+++ b/src/core/hooks/hooks.h
@@ -4,7 +4,6 @@
 #include "../interfaces.h"
 #include <dxgi.h>
 
-// Virtual table indexes — single source of truth for all vtable offsets
 namespace VTABLE
 {
     enum
@@ -14,11 +13,14 @@ namespace VTABLE
         RESIZEBUFFERS = 13,
 
         /* InputSystem */
-        ISRELATIVEMOUSEMODE = 76
+        ISRELATIVEMOUSEMODE = 76,
+
+        /* CCSGOInput */
+        CREATEMOVE = 5,
+        CREATEMOVE_INNER = 22
     };
 }
 
-// Detour instances - one HookManager per hooked function
 namespace DTR
 {
     inline HookManager Present;
@@ -26,6 +28,7 @@ namespace DTR
     inline HookManager IsRelativeMouseMode;
     inline HookManager SDLSetRelMouseMode;
     inline HookManager CreateMove;
+    inline HookManager CreateMoveInner;
 }
 
 namespace H
@@ -33,6 +36,5 @@ namespace H
     bool Setup();
     void Restore();
 
-    // Original WndProc (subclassed, not detoured) — stored here because Restore() unsubclasses
     inline WNDPROC oWndProc = nullptr;
 }

--- a/src/core/interfaces.cpp
+++ b/src/core/interfaces.cpp
@@ -2,6 +2,8 @@
 // D3D11 device/swapchain via dummy window + Source 2 CreateInterface
 
 #include "interfaces.h"
+#include "../sdk/entitysystem.h"
+#include "../sdk/usercmd.h"
 #include "../utilities/debug.h"
 #include "../utilities/memory.h"
 #include <format>
@@ -111,8 +113,9 @@ bool I::Setup()
     C::Print(
         std::format("[interfaces] IGameResourceService: {:#x}", reinterpret_cast<uintptr_t>(pGameResourceService)));
 
-    // CGameEntitySystem is at offset 0x58 from IGameResourceService
-    pEntitySystem = *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(pGameResourceService) + 0x58);
+    // CGameEntitySystem at IGameResourceService+0x58
+    pEntitySystem =
+        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(pGameResourceService) + Offsets::pEntitySystem);
     if (!pEntitySystem)
     {
         C::Print("[interfaces] WARNING: CGameEntitySystem is null (may not be initialized yet)");
@@ -122,19 +125,30 @@ bool I::Setup()
         C::Print(std::format("[interfaces] CGameEntitySystem: {:#x}", reinterpret_cast<uintptr_t>(pEntitySystem)));
     }
 
-    // CCSGOInput — resolve via pattern scan (dwCSGOInput offset is not a heap object in this build)
+    // CCSGOInput — inline global in client.dll at dwCSGOInput offset
     {
-        uintptr_t pCreateMove =
-            M::FindPattern("client.dll", "48 8B C4 4C 89 40 18 48 89 48 08 55 53 41 54 41 55 48 8D A8 F8 FE FF FF");
+        uintptr_t clientBase = reinterpret_cast<uintptr_t>(GetModuleHandleA("client.dll"));
+        pCSGOInput = reinterpret_cast<void*>(clientBase + Offsets::dwCSGOInput);
+        C::Print(std::format("[interfaces] CCSGOInput @ {:#x} (client+{:#x})", reinterpret_cast<uintptr_t>(pCSGOInput),
+                             Offsets::dwCSGOInput));
+    }
 
-        if (pCreateMove)
+    // Subtick: resolve fnCreateElement + fnAddToField from inlined add_subtick_moves code
+    // Pattern: E8 [createElement] 48 8B D0 48 8D 4F 18 E8 [addToField] 48 8B D0
+    // These are called by the engine's own subtick creation logic (inlined, not a standalone fn)
+    {
+        uintptr_t addr = M::FindPattern("client.dll", "E8 ? ? ? ? 48 8B D0 48 8D 4F 18 E8 ? ? ? ? 48 8B D0");
+        if (addr)
         {
-            pCSGOInput = reinterpret_cast<void*>(pCreateMove);
-            C::Print(std::format("[interfaces] CreateMove found @ {:#x}", pCreateMove));
+            Subtick::fnCreateElement = reinterpret_cast<Subtick::CreateElementFn>(M::ResolveRelative(addr, 1, 5));
+            Subtick::fnAddToField = reinterpret_cast<Subtick::AddToFieldFn>(M::ResolveRelative(addr + 12, 1, 5));
+            C::Print(std::format("[interfaces] subtick: createElement={:#x} addToField={:#x}",
+                                 reinterpret_cast<uintptr_t>(Subtick::fnCreateElement),
+                                 reinterpret_cast<uintptr_t>(Subtick::fnAddToField)));
         }
         else
         {
-            C::Print("[interfaces] WARNING: CreateMove pattern not found");
+            C::Print("[interfaces] subtick pattern not found (subtick disabled)");
         }
     }
 

--- a/src/core/interfaces.cpp
+++ b/src/core/interfaces.cpp
@@ -127,7 +127,7 @@ bool I::Setup()
 
     // CCSGOInput — inline global in client.dll at dwCSGOInput offset
     {
-        uintptr_t clientBase = reinterpret_cast<uintptr_t>(GetModuleHandleA("client.dll"));
+        auto clientBase = reinterpret_cast<uintptr_t>(GetModuleHandleA("client.dll"));
         pCSGOInput = reinterpret_cast<void*>(clientBase + Offsets::dwCSGOInput);
         C::Print(std::format("[interfaces] CCSGOInput @ {:#x} (client+{:#x})", reinterpret_cast<uintptr_t>(pCSGOInput),
                              Offsets::dwCSGOInput));

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -22,6 +22,6 @@ namespace I
     inline void* pGameResourceService = nullptr; // IGameResourceService from engine2.dll
     inline void* pEntitySystem = nullptr;        // CGameEntitySystem* (offset 0x58 from resource service)
 
-    // CreateMove function address — resolved via pattern scan in client.dll
+    // CCSGOInput object pointer — resolved via dwCSGOInput offset, used for vtable[5] hooking
     inline void* pCSGOInput = nullptr;
 }

--- a/src/core/menu/menu.cpp
+++ b/src/core/menu/menu.cpp
@@ -23,7 +23,8 @@ void Menu::Render()
 
         if (ImGui::CollapsingHeader("Misc"))
         {
-            ImGui::Checkbox("Bunny Hop", &Vars.bBunnyHop);
+            static const char* bhopModes[] = {"Disabled", "Normal", "Subtick"};
+            ImGui::Combo("Bunny Hop", &Vars.nBhopMode, bhopModes, IM_ARRAYSIZE(bhopModes));
         }
 
         ImGui::Separator();

--- a/src/core/variables.h
+++ b/src/core/variables.h
@@ -7,7 +7,13 @@ struct Variables_t
     bool bESP = false;
 
     // Misc
-    bool bBunnyHop = false;
+    enum BhopMode : int
+    {
+        BHOP_DISABLED = 0,
+        BHOP_NORMAL,
+        BHOP_SUBTICK
+    };
+    int nBhopMode = BHOP_DISABLED;
 };
 
 inline Variables_t Vars;

--- a/src/features/movement.cpp
+++ b/src/features/movement.cpp
@@ -1,61 +1,33 @@
-// Movement features — bunny hop
-// Wired into CreateMove via createmove.cpp
-//
-// Uses ForceJump state machine (adapted from saura07) for reliable bhop.
-// Queries EntitySystem for player state — no raw offsets in feature code.
+// Movement features — bunny hop via direct button manipulation
+// Called from vtable[22]: clears jump on ground, optionally injects subtick entries
 
 #include "movement.h"
 #include "../sdk/entitysystem.h"
+#include "../sdk/usercmd.h"
 #include "../core/variables.h"
 #include "../utilities/inputhook.h"
 
-void Movement::BunnyHop()
+void Movement::BunnyHop(CUserCmd* pCmd, C_BaseEntity* pLocal)
 {
-    if (!Vars.bBunnyHop)
+    if (Vars.nBhopMode == Variables_t::BHOP_DISABLED || !pCmd)
         return;
 
-    if (!EntitySystem::InitForceJump())
+    if (!Input::bSpaceHeld.load(std::memory_order_relaxed))
         return;
 
-    bool bSpaceHeld = Input::bSpaceHeld.load(std::memory_order_relaxed);
-
-    // State machine (adapted from saura07 CS:GO bhop)
-    // bLastJumped: we forced jump last tick while on ground
-    // bShouldFake: try forcing jump again to catch narrow landing windows
-    static bool bLastJumped = false, bShouldFake = false;
-
-    if (!bSpaceHeld)
-    {
-        bLastJumped = false;
-        bShouldFake = false;
-        return;
-    }
-
-    void* pPawn = EntitySystem::GetLocalPlayerPawn();
-    if (!pPawn)
+    if (pLocal->m_MoveType == MOVETYPE_LADDER || pLocal->m_MoveType == MOVETYPE_NOCLIP ||
+        pLocal->m_MoveType == MOVETYPE_OBSERVER)
         return;
 
-    uint8_t moveType = GetField<uint8_t>(pPawn, Offsets::m_MoveType);
-    if (moveType == MOVETYPE_LADDER || moveType == MOVETYPE_NOCLIP || moveType == MOVETYPE_OBSERVER ||
-        moveType == MOVETYPE_FLY)
+    if (!(pLocal->m_fFlags & FL_ONGROUND))
         return;
 
-    bool bOnGround = (GetField<uint32_t>(pPawn, Offsets::m_fFlags) & FL_ONGROUND) != 0;
+    constexpr uint64_t jump = static_cast<uint64_t>(IN_JUMP);
 
-    if (!bLastJumped && bShouldFake)
-    {
-        bShouldFake = false;
-        EntitySystem::SetForceJump(true);
-    }
-    else if (bOnGround)
-    {
-        bLastJumped = true;
-        bShouldFake = true;
-        EntitySystem::SetForceJump(true);
-    }
-    else
-    {
-        EntitySystem::SetForceJump(false);
-        bLastJumped = false;
-    }
+    // Clear jump to force a release — engine re-sets from space next frame
+    pCmd->nButtons.nValue &= ~jump;
+
+    // Subtick: inject press/release entries for timing
+    if (Vars.nBhopMode == Variables_t::BHOP_SUBTICK && Subtick::fnCreateElement && IsValidPtr(pCmd->pBaseCmd))
+        Subtick::Inject(pCmd->pBaseCmd, jump);
 }

--- a/src/features/movement.cpp
+++ b/src/features/movement.cpp
@@ -22,7 +22,7 @@ void Movement::BunnyHop(CUserCmd* pCmd, const C_BaseEntity* pLocal)
     if (!(pLocal->m_fFlags & FL_ONGROUND))
         return;
 
-    constexpr uint64_t jump = static_cast<uint64_t>(IN_JUMP);
+    constexpr auto jump = static_cast<uint64_t>(IN_JUMP);
 
     // Clear jump to force a release — engine re-sets from space next frame
     pCmd->nButtons.nValue &= ~jump;

--- a/src/features/movement.cpp
+++ b/src/features/movement.cpp
@@ -7,7 +7,7 @@
 #include "../core/variables.h"
 #include "../utilities/inputhook.h"
 
-void Movement::BunnyHop(CUserCmd* pCmd, C_BaseEntity* pLocal)
+void Movement::BunnyHop(CUserCmd* pCmd, const C_BaseEntity* pLocal)
 {
     if (Vars.nBhopMode == Variables_t::BHOP_DISABLED || !pCmd)
         return;

--- a/src/features/movement.h
+++ b/src/features/movement.h
@@ -10,5 +10,5 @@ struct C_BaseEntity;
 namespace Movement
 {
     // Called from vtable[22] — clears jump on ground + optional subtick entries
-    void BunnyHop(CUserCmd* pCmd, C_BaseEntity* pLocal);
+    void BunnyHop(CUserCmd* pCmd, const C_BaseEntity* pLocal);
 }

--- a/src/features/movement.h
+++ b/src/features/movement.h
@@ -1,9 +1,14 @@
 #pragma once
-#include <cstdint>
+
+struct CInButtonState;
+struct CUserCmd;
+struct C_BaseEntity;
 
 // Movement features (bunny hop, etc.)
+// CS2 subtick engine handles press/release internally — we only need to
+// clear IN_JUMP on ground to force a release, engine re-presses from held space.
 namespace Movement
 {
-    // Called from CreateMove — queries EntitySystem for player state
-    void BunnyHop();
+    // Called from vtable[22] — clears jump on ground + optional subtick entries
+    void BunnyHop(CUserCmd* pCmd, C_BaseEntity* pLocal);
 }

--- a/src/sdk/entitysystem.cpp
+++ b/src/sdk/entitysystem.cpp
@@ -1,12 +1,7 @@
-// Entity system access — local player, button state
+// Entity system access — local player
 
 #include "entitysystem.h"
-#include "../utilities/debug.h"
-#include <format>
-
-// -----------------------------------------------------------------------
-// Module base
-// -----------------------------------------------------------------------
+#include <Windows.h>
 
 uintptr_t EntitySystem::GetClientBase()
 {
@@ -20,82 +15,11 @@ uintptr_t EntitySystem::GetClientBase()
     return base;
 }
 
-// -----------------------------------------------------------------------
-// Local player
-// -----------------------------------------------------------------------
-
-void* EntitySystem::GetLocalPlayerController()
+C_BaseEntity* EntitySystem::GetLocalPlayerPawn()
 {
     uintptr_t base = GetClientBase();
     if (!base)
         return nullptr;
 
-    return *reinterpret_cast<void**>(base + Offsets::dwLocalPlayerController);
-}
-
-void* EntitySystem::GetLocalPlayerPawn()
-{
-    uintptr_t base = GetClientBase();
-    if (!base)
-        return nullptr;
-
-    return *reinterpret_cast<void**>(base + Offsets::dwLocalPlayerPawn);
-}
-
-// -----------------------------------------------------------------------
-// Local player field accessors
-// -----------------------------------------------------------------------
-
-uint32_t EntitySystem::GetLocalPlayerFlags()
-{
-    void* pPawn = GetLocalPlayerPawn();
-    if (!pPawn)
-        return 0;
-
-    return GetField<uint32_t>(pPawn, Offsets::m_fFlags);
-}
-
-uint8_t EntitySystem::GetLocalMoveType()
-{
-    void* pPawn = GetLocalPlayerPawn();
-    if (!pPawn)
-        return MOVETYPE_NONE;
-
-    return GetField<uint8_t>(pPawn, Offsets::m_MoveType);
-}
-
-// -----------------------------------------------------------------------
-// ForceJump — button force state at buttons::jump + 0x00
-// -----------------------------------------------------------------------
-
-static constexpr uint32_t FORCE_JUMP_ON = 65537; // 0x10001
-static constexpr uint32_t FORCE_JUMP_OFF = 256;  // 0x100
-
-static uint32_t* s_pForceJump = nullptr;
-static bool s_forceJumpInitDone = false;
-
-bool EntitySystem::InitForceJump()
-{
-    if (s_forceJumpInitDone)
-        return s_pForceJump != nullptr;
-    s_forceJumpInitDone = true;
-
-    uintptr_t clientBase = GetClientBase();
-    if (!clientBase)
-    {
-        C::Print("[entitysystem] ForceJump init failed — client.dll base not found");
-        return false;
-    }
-
-    s_pForceJump = reinterpret_cast<uint32_t*>(clientBase + ButtonOffsets::jump);
-
-    C::Print(std::format("[entitysystem] ForceJump @ {:#x}, current value: {:#x}",
-                         reinterpret_cast<uintptr_t>(s_pForceJump), *s_pForceJump));
-    return true;
-}
-
-void EntitySystem::SetForceJump(bool bForce)
-{
-    if (s_pForceJump)
-        *s_pForceJump = bForce ? FORCE_JUMP_ON : FORCE_JUMP_OFF;
+    return *reinterpret_cast<C_BaseEntity**>(base + Offsets::dwLocalPlayerPawn);
 }

--- a/src/sdk/entitysystem.h
+++ b/src/sdk/entitysystem.h
@@ -53,6 +53,7 @@ enum ECommandButtons : uint64_t
 // -----------------------------------------------------------------------
 // C_BaseEntity — partial struct (cs2-dumper offsets, March 2026)
 // -----------------------------------------------------------------------
+// cppcheck-suppress noConstructor
 struct C_BaseEntity
 {
     MEM_PAD(0x354);        // +0x000

--- a/src/sdk/entitysystem.h
+++ b/src/sdk/entitysystem.h
@@ -53,7 +53,6 @@ enum ECommandButtons : uint64_t
 // -----------------------------------------------------------------------
 // C_BaseEntity — partial struct (cs2-dumper offsets, March 2026)
 // -----------------------------------------------------------------------
-// cppcheck-suppress noConstructor
 struct C_BaseEntity
 {
     MEM_PAD(0x354);        // +0x000

--- a/src/sdk/entitysystem.h
+++ b/src/sdk/entitysystem.h
@@ -1,29 +1,23 @@
 #pragma once
-#include "../includes.h"
+#include <cstdint>
+#include <cstddef>
+#include "../utilities/memory.h"
 
 // -----------------------------------------------------------------------
-// Offsets from cs2-dumper (2026-03-12)
-// These are hardcoded — will break on game updates.
+// Offsets from cs2-dumper — 2026-03-19
 // -----------------------------------------------------------------------
 namespace Offsets
 {
-    // client.dll globals (cs2-dumper 2026-03-12)
-    constexpr uintptr_t dwLocalPlayerController = 0x22F3178;
-    constexpr uintptr_t dwLocalPlayerPawn = 0x2068B60;
-    constexpr uintptr_t dwEntityList = 0x24AE268;
+    // client.dll globals
+    constexpr uintptr_t dwLocalPlayerController = 0x22F4188;
+    constexpr uintptr_t dwLocalPlayerPawn = 0x2069B50;
+    constexpr uintptr_t dwEntityList = 0x24AF268;
 
-    // CCSPlayerController
-    constexpr uintptr_t m_hPlayerPawn = 0x90C;
+    // CCSGOInput object (inline global in client.dll .data)
+    constexpr uintptr_t dwCSGOInput = 0x2319FC0;
 
-    // C_BaseEntity
-    constexpr uintptr_t m_fFlags = 0x400;
-    constexpr uintptr_t m_iHealth = 0x354;
-    constexpr uintptr_t m_lifeState = 0x35C;
-    constexpr uintptr_t m_vecVelocity = 0x438;
-    constexpr uintptr_t m_MoveType = 0x52D; // MoveType_t (uint8)
-
-    // C_BasePlayerPawn
-    constexpr uintptr_t m_pMovementServices = 0x1418;
+    // IGameResourceService
+    constexpr uintptr_t pEntitySystem = 0x58; // CGameEntitySystem* at IGameResourceService+0x58
 }
 
 // -----------------------------------------------------------------------
@@ -34,19 +28,14 @@ constexpr uint32_t FL_ONGROUND = (1 << 0);
 enum MoveType_t : uint8_t
 {
     MOVETYPE_NONE = 0,
-    MOVETYPE_OBSOLETE = 1,
     MOVETYPE_WALK = 2,
     MOVETYPE_FLY = 3,
-    MOVETYPE_FLYGRAVITY = 4,
-    MOVETYPE_VPHYSICS = 5,
-    MOVETYPE_PUSH = 6,
     MOVETYPE_NOCLIP = 7,
     MOVETYPE_LADDER = 8,
-    MOVETYPE_OBSERVER = 9,
-    MOVETYPE_CUSTOM = 10
+    MOVETYPE_OBSERVER = 9
 };
 
-// CS2 button flags for CInButtonState::nValue
+// CS2 button flags
 enum ECommandButtons : uint64_t
 {
     IN_ATTACK = 1ULL << 0,
@@ -61,48 +50,30 @@ enum ECommandButtons : uint64_t
     IN_SPRINT = 1ULL << 16
 };
 
-// Button state container (CInButtonState from CS2 SDK)
-struct CInButtonState
+// -----------------------------------------------------------------------
+// C_BaseEntity — partial struct (cs2-dumper offsets, March 2026)
+// -----------------------------------------------------------------------
+struct C_BaseEntity
 {
-    uint8_t _pad0[0x8];     // 0x00 vtable pointer
-    uint64_t nValue;        // 0x08 current pressed buttons
-    uint64_t nValueChanged; // 0x10 buttons that changed this tick
-    uint64_t nValueScroll;  // 0x18 scroll-related state
+    MEM_PAD(0x354);        // +0x000
+    int32_t m_iHealth;     // +0x354
+    MEM_PAD(0x04);         // +0x358
+    uint8_t m_lifeState;   // +0x35C
+    MEM_PAD(0xA3);         // +0x35D
+    uint32_t m_fFlags;     // +0x400
+    MEM_PAD(0x129);        // +0x404
+    MoveType_t m_MoveType; // +0x52D
 };
-static_assert(sizeof(CInButtonState) == 0x20, "CInButtonState size mismatch");
-
-// -----------------------------------------------------------------------
-// Global button state offsets (cs2-dumper buttons.hpp, client.dll)
-// buttons::jump + 0x00 is the ForceJump uint32 (no vtable at this address).
-// Write 0x10001 to force jump, 0x100 to release.
-// -----------------------------------------------------------------------
-namespace ButtonOffsets
-{
-    constexpr uintptr_t jump = 0x2061E00;
-}
+static_assert(offsetof(C_BaseEntity, m_iHealth) == 0x354);
+static_assert(offsetof(C_BaseEntity, m_lifeState) == 0x35C);
+static_assert(offsetof(C_BaseEntity, m_fFlags) == 0x400);
+static_assert(offsetof(C_BaseEntity, m_MoveType) == 0x52D);
 
 // -----------------------------------------------------------------------
 // Entity system helpers
 // -----------------------------------------------------------------------
-// Read a field at a given offset from an entity pointer
-template <typename T> inline T GetField(void* pEntity, uintptr_t offset)
-{
-    return *reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(pEntity) + offset);
-}
-
 namespace EntitySystem
 {
     uintptr_t GetClientBase();
-
-    // Local player pointers
-    void* GetLocalPlayerController();
-    void* GetLocalPlayerPawn();
-
-    // Local player field accessors — wraps offset reads so features stay clean
-    uint32_t GetLocalPlayerFlags();
-    uint8_t GetLocalMoveType();
-
-    // ForceJump — resolves buttons::jump once, then caches.
-    bool InitForceJump();
-    void SetForceJump(bool bForce);
+    C_BaseEntity* GetLocalPlayerPawn();
 }

--- a/src/sdk/usercmd.cpp
+++ b/src/sdk/usercmd.cpp
@@ -11,7 +11,7 @@ static struct
     struct
     {
         int allocatedSize;
-        int _pad; // NOLINT — engine Rep_t alignment
+        int _pad;
         void* elements[2];
     } rep;
     RepeatedPtrField saved;

--- a/src/sdk/usercmd.cpp
+++ b/src/sdk/usercmd.cpp
@@ -11,7 +11,7 @@ static struct
     struct
     {
         int allocatedSize;
-        int _pad; // cppcheck-suppress unusedStructMember
+        MEM_PAD(0x04);
         void* elements[2];
     } rep;
     RepeatedPtrField saved;

--- a/src/sdk/usercmd.cpp
+++ b/src/sdk/usercmd.cpp
@@ -10,8 +10,7 @@ static struct
     CSubtickMoveStep* step1;
     struct
     {
-        int allocatedSize;
-        MEM_PAD(0x04);
+        uint64_t allocatedSize;
         void* elements[2];
     } rep;
     RepeatedPtrField saved;

--- a/src/sdk/usercmd.cpp
+++ b/src/sdk/usercmd.cpp
@@ -1,0 +1,59 @@
+// Subtick inject/restore — mutable state lives here (single TU)
+
+#include "usercmd.h"
+
+// Static Rep + steps (created once via fnCreateElement, reused forever)
+static struct
+{
+    bool initialized;
+    CSubtickMoveStep* step0;
+    CSubtickMoveStep* step1;
+    struct
+    {
+        int allocatedSize;
+        int _pad;
+        void* elements[2];
+    } rep;
+    RepeatedPtrField saved;
+    CBaseUserCmdPB* activePBase;
+} s_state = {};
+
+void Subtick::Inject(CBaseUserCmdPB* pBase, uint64_t button, float flWhenPress, float flWhenRelease)
+{
+    if (!fnCreateElement)
+        return;
+
+    if (!s_state.initialized)
+    {
+        s_state.step0 = static_cast<CSubtickMoveStep*>(fnCreateElement(nullptr));
+        s_state.step1 = static_cast<CSubtickMoveStep*>(fnCreateElement(nullptr));
+        if (!s_state.step0 || !s_state.step1)
+            return;
+        s_state.rep.allocatedSize = 2;
+        s_state.rep.elements[0] = s_state.step0;
+        s_state.rep.elements[1] = s_state.step1;
+        s_state.initialized = true;
+    }
+
+    WriteStep(s_state.step0, button, true, flWhenPress);
+    WriteStep(s_state.step1, button, false, flWhenRelease);
+
+    // Save original field state
+    s_state.saved = pBase->subtickMoves;
+
+    // Inject our static Rep
+    pBase->subtickMoves.nCurrentSize = 2;
+    pBase->subtickMoves.nTotalSize = 2;
+    pBase->subtickMoves.pRep = &s_state.rep;
+
+    s_state.activePBase = pBase;
+}
+
+void Subtick::Restore(CBaseUserCmdPB* pBase)
+{
+    if (!pBase || pBase != s_state.activePBase)
+        return;
+
+    pBase->subtickMoves = s_state.saved;
+    s_state.activePBase = nullptr;
+}

--- a/src/sdk/usercmd.cpp
+++ b/src/sdk/usercmd.cpp
@@ -11,7 +11,7 @@ static struct
     struct
     {
         int allocatedSize;
-        int _pad;
+        int _pad; // cppcheck-suppress unusedStructMember
         void* elements[2];
     } rep;
     RepeatedPtrField saved;

--- a/src/sdk/usercmd.cpp
+++ b/src/sdk/usercmd.cpp
@@ -11,7 +11,7 @@ static struct
     struct
     {
         int allocatedSize;
-        int _pad;
+        int _pad; // NOLINT — engine Rep_t alignment
         void* elements[2];
     } rep;
     RepeatedPtrField saved;

--- a/src/sdk/usercmd.h
+++ b/src/sdk/usercmd.h
@@ -41,6 +41,7 @@ static_assert(sizeof(RepeatedPtrField) == 0x18);
 
 // CBasePB — protobuf base class (0x10 bytes)
 // All protobuf message types (CSubtickMoveStep, CBaseUserCmdPB, CInButtonStatePB) inherit this
+// cppcheck-suppress noConstructor
 struct CBasePB
 {
     MEM_PAD(0x08);        // +0x00: vtable
@@ -52,6 +53,7 @@ static_assert(offsetof(CBasePB, nHasBits) == 0x08);
 
 // CInButtonState (0x20 bytes, inline in CUserCmd at +0x58 and CCSGOInput at +0x248)
 // NOT a protobuf type — simple struct with vtable
+// cppcheck-suppress noConstructor
 struct CInButtonState
 {
     MEM_PAD(0x08);     // +0x00: vtable
@@ -64,6 +66,7 @@ static_assert(offsetof(CInButtonState, nValue) == 0x08);
 
 // CSubtickMoveStep : CBasePB (0x20 bytes, March 2026)
 // Fields shifted -8 from asphyxia Nov 2024 layout
+// cppcheck-suppress noConstructor
 struct CSubtickMoveStep : CBasePB
 {
     uint64_t nButton; // +0x10 — button enum (IN_JUMP etc)
@@ -78,6 +81,7 @@ static_assert(offsetof(CSubtickMoveStep, flWhen) == 0x1C);
 
 // CBaseUserCmdPB : CBasePB (protobuf, March 2026)
 // Layout matches asphyxia Nov 2024 through +0x40, but flForwardMove shifted +8
+// cppcheck-suppress noConstructor
 struct CBaseUserCmdPB : CBasePB
 {
     MEM_PAD(0x08);                 // +0x10: unknown field
@@ -94,6 +98,7 @@ static_assert(offsetof(CBaseUserCmdPB, pInButtonStatePB) == 0x38);
 static_assert(offsetof(CBaseUserCmdPB, flForwardMove) == 0x58);
 
 // CUserCmd (0x98 bytes)
+// cppcheck-suppress noConstructor
 struct CUserCmd
 {
     MEM_PAD(0x08);            // +0x00: vtable

--- a/src/sdk/usercmd.h
+++ b/src/sdk/usercmd.h
@@ -1,0 +1,175 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include "../utilities/memory.h"
+
+// -----------------------------------------------------------------------
+// Pointer validation
+// -----------------------------------------------------------------------
+inline bool IsValidPtr(const void* ptr)
+{
+    auto addr = reinterpret_cast<uintptr_t>(ptr);
+    return addr > 0x10000 && addr < 0x7FFFFFFFFFFF;
+}
+
+// -----------------------------------------------------------------------
+// CCSGOInput offset (struct not fully mapped — accessor below)
+// -----------------------------------------------------------------------
+namespace InputOffsets
+{
+    constexpr uintptr_t nButtonState = 0x248; // CInButtonState at CCSGOInput+0x248
+    // nButtonState+0x08 = 0x250 = nValue  (confirmed via probing March 2026)
+    // nButtonState+0x10 = 0x258 = nChanged
+}
+
+// -----------------------------------------------------------------------
+// SDK structs — March 2026 build
+// All offsets confirmed via vtable[22] probing
+// -----------------------------------------------------------------------
+
+// Protobuf RepeatedPtrField (0x18 bytes)
+// Engine layout: { void* pArena, int nCurrentSize, int nTotalSize, Rep_t* pRep }
+// Rep_t layout: { int allocatedSize(4), pad(4), void* elements[](at +8) }
+struct RepeatedPtrField
+{
+    void* pArena;     // +0x00 — protobuf arena (always null on this build)
+    int nCurrentSize; // +0x08 — current entry count
+    int nTotalSize;   // +0x0C — total allocated
+    void* pRep;       // +0x10 — Rep_t* (element pointer array)
+};
+static_assert(sizeof(RepeatedPtrField) == 0x18);
+
+// CBasePB — protobuf base class (0x10 bytes)
+// All protobuf message types (CSubtickMoveStep, CBaseUserCmdPB, CInButtonStatePB) inherit this
+struct CBasePB
+{
+    MEM_PAD(0x08);        // +0x00: vtable
+    uint32_t nHasBits;    // +0x08 — protobuf has-bits (marks which fields are set)
+    uint32_t nCachedSize; // +0x0C — protobuf cached serialization size
+};
+static_assert(sizeof(CBasePB) == 0x10);
+static_assert(offsetof(CBasePB, nHasBits) == 0x08);
+
+// CInButtonState (0x20 bytes, inline in CUserCmd at +0x58 and CCSGOInput at +0x248)
+// NOT a protobuf type — simple struct with vtable
+struct CInButtonState
+{
+    MEM_PAD(0x08);     // +0x00: vtable
+    uint64_t nValue;   // +0x08 — current pressed buttons (IN_JUMP etc)
+    uint64_t nChanged; // +0x10 — buttons changed this tick
+    uint64_t nScroll;  // +0x18 — scroll buttons
+};
+static_assert(sizeof(CInButtonState) == 0x20);
+static_assert(offsetof(CInButtonState, nValue) == 0x08);
+
+// CSubtickMoveStep : CBasePB (0x20 bytes, March 2026)
+// Fields shifted -8 from asphyxia Nov 2024 layout
+struct CSubtickMoveStep : CBasePB
+{
+    uint64_t nButton; // +0x10 — button enum (IN_JUMP etc)
+    bool bPressed;    // +0x18 — press (true) or release (false)
+    MEM_PAD(3);       // +0x19
+    float flWhen;     // +0x1C — 0.0-1.0 normalized time within tick
+};
+static_assert(sizeof(CSubtickMoveStep) == 0x20);
+static_assert(offsetof(CSubtickMoveStep, nButton) == 0x10);
+static_assert(offsetof(CSubtickMoveStep, bPressed) == 0x18);
+static_assert(offsetof(CSubtickMoveStep, flWhen) == 0x1C);
+
+// CBaseUserCmdPB : CBasePB (protobuf, March 2026)
+// Layout matches asphyxia Nov 2024 through +0x40, but flForwardMove shifted +8
+struct CBaseUserCmdPB : CBasePB
+{
+    MEM_PAD(0x08);                 // +0x10: unknown field
+    RepeatedPtrField subtickMoves; // +0x18 — subtick move steps (0x18 bytes)
+    uint64_t nMoveCrc;             // +0x30 — CRC-like value
+    void* pInButtonStatePB;        // +0x38 — CInButtonStatePB* (protobuf buttons)
+    void* pViewAngles;             // +0x40 — CMsgQAngle*
+    MEM_PAD(0x10);                 // +0x48 — nLegacyCommandNumber + nClientTick + new field
+    float flForwardMove;           // +0x58 — forward/back movement
+    float flSideMove;              // +0x5C — left/right movement
+};
+static_assert(offsetof(CBaseUserCmdPB, subtickMoves) == 0x18);
+static_assert(offsetof(CBaseUserCmdPB, pInButtonStatePB) == 0x38);
+static_assert(offsetof(CBaseUserCmdPB, flForwardMove) == 0x58);
+
+// CUserCmd (0x98 bytes)
+struct CUserCmd
+{
+    MEM_PAD(0x08);            // +0x00: vtable
+    uint32_t nCmdNumber;      // +0x08 — command sequence number
+    MEM_PAD(0x34);            // +0x0C
+    CBaseUserCmdPB* pBaseCmd; // +0x40 — protobuf base command
+    MEM_PAD(0x10);            // +0x48
+    CInButtonState nButtons;  // +0x58 — inline button state (NOT protobuf)
+};
+static_assert(offsetof(CUserCmd, nCmdNumber) == 0x08);
+static_assert(offsetof(CUserCmd, pBaseCmd) == 0x40);
+static_assert(offsetof(CUserCmd, nButtons) == 0x58);
+
+// -----------------------------------------------------------------------
+// Subtick dirty bits
+// -----------------------------------------------------------------------
+constexpr uint32_t MOVESTEP_BITS_BUTTON = 0x1;
+constexpr uint32_t MOVESTEP_BITS_PRESSED = 0x2;
+constexpr uint32_t MOVESTEP_BITS_WHEN = 0x4;
+constexpr uint32_t MOVESTEP_BITS_ALL = MOVESTEP_BITS_BUTTON | MOVESTEP_BITS_PRESSED | MOVESTEP_BITS_WHEN;
+
+// CInButtonStatePB has-bits
+constexpr uint32_t BTNPB_BITS_VALUE = 0x1;
+constexpr uint32_t BTNPB_BITS_CHANGED = 0x2;
+constexpr uint32_t BTNPB_BITS_SCROLL = 0x4;
+
+// -----------------------------------------------------------------------
+// CCSGOInput accessor (returns CInButtonState* for live button state)
+// -----------------------------------------------------------------------
+namespace CInput
+{
+    inline CInButtonState* GetButtonState(void* pInput)
+    {
+        return reinterpret_cast<CInButtonState*>(reinterpret_cast<uintptr_t>(pInput) + InputOffsets::nButtonState);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Subtick — CBaseUserCmdPB subtick entry manipulation
+//
+// General-purpose: any feature can inject subtick steps into a command.
+// Uses static objects (allocated once, never freed by engine) with an
+// inject/restore pattern around the original hook call.
+//
+// Usage from a hook:
+//   BEFORE original: Subtick::Inject(pCmd->pBaseCmd, button, press)
+//   call original
+//   AFTER original:  Subtick::Restore(pCmd->pBaseCmd)
+// -----------------------------------------------------------------------
+namespace Subtick
+{
+    // Function pointers resolved from engine pattern in interfaces.cpp
+    // Pattern: E8 ? ? ? ? 48 8B D0 48 8D 4F 18 E8 ? ? ? ?
+    using CreateElementFn = void*(__fastcall*)(void* pArena);
+    using AddToFieldFn = void*(__fastcall*)(void* pRepeatedField, void* pElement);
+    inline CreateElementFn fnCreateElement = nullptr;
+    inline AddToFieldFn fnAddToField = nullptr;
+
+    // Write fields into a CSubtickMoveStep
+    inline void WriteStep(CSubtickMoveStep* pStep, uint64_t button, bool pressed, float when)
+    {
+        if (!pStep)
+            return;
+
+        pStep->nHasBits |= MOVESTEP_BITS_ALL;
+        pStep->nButton = button;
+        pStep->bPressed = pressed;
+        pStep->flWhen = when;
+    }
+
+    // Inject two subtick entries (press + release) into CBaseUserCmdPB.
+    // Press at start of tick, release mid-tick — tight scroll-like window.
+    // Saves original field state for Restore(). Call BEFORE the original hook.
+    void Inject(CBaseUserCmdPB* pBase, uint64_t button, float flWhenPress = 0.015625f, float flWhenRelease = 0.65f);
+
+    // Restore original subtick field state. Call AFTER the original hook returns.
+    // Prevents engine cleanup from freeing our static objects.
+    void Restore(CBaseUserCmdPB* pBase);
+}

--- a/src/sdk/usercmd.h
+++ b/src/sdk/usercmd.h
@@ -41,7 +41,7 @@ static_assert(sizeof(RepeatedPtrField) == 0x18);
 
 // CBasePB — protobuf base class (0x10 bytes)
 // All protobuf message types (CSubtickMoveStep, CBaseUserCmdPB, CInButtonStatePB) inherit this
-// cppcheck-suppress noConstructor
+
 struct CBasePB
 {
     MEM_PAD(0x08);        // +0x00: vtable
@@ -53,7 +53,6 @@ static_assert(offsetof(CBasePB, nHasBits) == 0x08);
 
 // CInButtonState (0x20 bytes, inline in CUserCmd at +0x58 and CCSGOInput at +0x248)
 // NOT a protobuf type — simple struct with vtable
-// cppcheck-suppress noConstructor
 struct CInButtonState
 {
     MEM_PAD(0x08);     // +0x00: vtable
@@ -66,7 +65,6 @@ static_assert(offsetof(CInButtonState, nValue) == 0x08);
 
 // CSubtickMoveStep : CBasePB (0x20 bytes, March 2026)
 // Fields shifted -8 from asphyxia Nov 2024 layout
-// cppcheck-suppress noConstructor
 struct CSubtickMoveStep : CBasePB
 {
     uint64_t nButton; // +0x10 — button enum (IN_JUMP etc)
@@ -81,7 +79,6 @@ static_assert(offsetof(CSubtickMoveStep, flWhen) == 0x1C);
 
 // CBaseUserCmdPB : CBasePB (protobuf, March 2026)
 // Layout matches asphyxia Nov 2024 through +0x40, but flForwardMove shifted +8
-// cppcheck-suppress noConstructor
 struct CBaseUserCmdPB : CBasePB
 {
     MEM_PAD(0x08);                 // +0x10: unknown field
@@ -98,7 +95,6 @@ static_assert(offsetof(CBaseUserCmdPB, pInButtonStatePB) == 0x38);
 static_assert(offsetof(CBaseUserCmdPB, flForwardMove) == 0x58);
 
 // CUserCmd (0x98 bytes)
-// cppcheck-suppress noConstructor
 struct CUserCmd
 {
     MEM_PAD(0x08);            // +0x00: vtable

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -4,7 +4,21 @@
 #include <string>
 #include <Windows.h>
 
+// -----------------------------------------------------------------------
+// Struct padding macro — use instead of manual char _padN[size]
+// Two-level expansion ensures __COUNTER__ resolves before ##
+// -----------------------------------------------------------------------
+#define MEM_PAD_CONCAT_INNER(a, b) a##b
+#define MEM_PAD_CONCAT(a, b) MEM_PAD_CONCAT_INNER(a, b)
+#define MEM_PAD(SIZE)                                                                                                  \
+  private:                                                                                                             \
+    char MEM_PAD_CONCAT(_pad_, __COUNTER__)[SIZE];                                                                     \
+                                                                                                                       \
+  public:
+
+// -----------------------------------------------------------------------
 // Memory utilities: pattern scanning, vtable access
+// -----------------------------------------------------------------------
 namespace M
 {
     // Scan a module for a byte pattern (IDA-style: "48 8B 05 ? ? ? ?")
@@ -18,6 +32,13 @@ namespace M
     {
         auto vtable = *reinterpret_cast<void***>(pClass);
         return reinterpret_cast<T>(vtable[index]);
+    }
+
+    // Call a virtual function by index (combines GetVFunc + invoke)
+    template <typename T, typename... Args> T CallVFunc(void* pClass, int index, Args... args)
+    {
+        using Fn = T(__thiscall*)(void*, Args...);
+        return (*static_cast<Fn**>(pClass))[index](pClass, args...);
     }
 
     // Get module base address and size

--- a/src/utilities/memory.h
+++ b/src/utilities/memory.h
@@ -10,11 +10,7 @@
 // -----------------------------------------------------------------------
 #define MEM_PAD_CONCAT_INNER(a, b) a##b
 #define MEM_PAD_CONCAT(a, b) MEM_PAD_CONCAT_INNER(a, b)
-#define MEM_PAD(SIZE)                                                                                                  \
-  private:                                                                                                             \
-    char MEM_PAD_CONCAT(_pad_, __COUNTER__)[SIZE];                                                                     \
-                                                                                                                       \
-  public:
+#define MEM_PAD(SIZE) char MEM_PAD_CONCAT(_pad_, __COUNTER__)[SIZE];
 
 // -----------------------------------------------------------------------
 // Memory utilities: pattern scanning, vtable access


### PR DESCRIPTION
- Replace external ForceJump with internal CCSGOInput vtable hooks (vtable[5] + vtable[22])
- Typed SDK structs (CUserCmd, CBaseUserCmdPB, CSubtickMoveStep, C_BaseEntity) with static_assert validation
- Subtick inject/restore pattern for frame-perfect jump timing
- CS2 bhop approach: clear IN_JUMP on ground, let engine handle press/release cycle
- MEM_PAD macro, CBasePB base class, CallVFunc template ported from saura07
- Cleaned include dependencies (entitysystem.h no longer pulls D3D11)